### PR TITLE
Add presentation type translators.

### DIFF
--- a/src/Command/Command.ts
+++ b/src/Command/Command.ts
@@ -9,6 +9,7 @@
 
 import { CommandDescription } from "./CommandDescription";
 import { CommandMeta } from "./CommandMeta";
+import { CommandTable } from "./CommandTable";
 import { ParsedKeywords } from "./ParsedKeywords";
 import { PresentationArgumentStream } from "./PresentationStream";
 
@@ -16,6 +17,7 @@ type CommandBase<TCommandMeta extends CommandMeta = CommandMeta> = {
   readonly description: CommandDescription<TCommandMeta>;
   // The normalised designator that was used to invoke the command.
   readonly designator: string[];
+  readonly commandTable: CommandTable;
 };
 
 export type Command<TCommandMeta extends CommandMeta = CommandMeta> =
@@ -52,6 +54,7 @@ export function makePartialCommand<
 >(
   stream: PresentationArgumentStream,
   commandDescription: CommandDescription<TCommandMeta>,
+  commandTable: CommandTable,
   designator: string[]
 ): PartialCommand<TCommandMeta> {
   return {
@@ -59,5 +62,6 @@ export function makePartialCommand<
     isPartial: true,
     description: commandDescription,
     designator,
+    commandTable,
   };
 }

--- a/src/Command/CommandExecutorHelper.ts
+++ b/src/Command/CommandExecutorHelper.ts
@@ -17,6 +17,7 @@ import { StandardPresentationArgumentStream } from "./PresentationStream";
 import { Presentation } from "./Presentation";
 import { KeywordPresentationType } from "../TextReader";
 import { Keyword } from "./Keyword";
+import { CommandTable } from "./CommandTable";
 
 export type CommandExecutorHelperOptions<
   TInvocationInformation,
@@ -87,6 +88,7 @@ export const CommandExecutorHelper = Object.freeze({
     TRestArgumentObjectType,
     TKeywordsMeta extends KeywordsMeta,
   >(
+    commandTable: CommandTable,
     command: CommandDescription<
       CommandMeta<
         TCommandContext,
@@ -137,6 +139,7 @@ export const CommandExecutorHelper = Object.freeze({
         ...flatKeywords,
         ...(options.rest ?? []),
       ]),
+      commandTable,
     } satisfies TPartialCommand;
     const parseResult = commandInvoker.parseCommand(
       options.info,

--- a/src/Command/KeywordParameterDescription.ts
+++ b/src/Command/KeywordParameterDescription.ts
@@ -21,7 +21,7 @@ import {
   PresentationSchemaType,
   SinglePresentationSchema,
   TopPresentationSchema,
-  checkPresentationSchema,
+  acceptPresentation,
   printPresentationSchema,
 } from "./PresentationSchema";
 import {
@@ -89,8 +89,14 @@ export class KeywordParser<TKeywordsMeta extends KeywordsMeta = KeywordsMeta> {
     const stream = partialCommand.stream;
     const nextItem = stream.peekItem();
     if (nextItem !== undefined && !(nextItem.object instanceof Keyword)) {
-      if (checkPresentationSchema(keyword.acceptor, nextItem)) {
-        return Ok(stream.readItem());
+      const acceptedPresentation = acceptPresentation(
+        keyword.acceptor,
+        partialCommand.commandTable,
+        nextItem
+      );
+      if (acceptedPresentation !== undefined) {
+        stream.readItem(); // consume the presentation from the stream.
+        return Ok(acceptedPresentation);
       } else {
         return ArgumentParseError.Result(
           `Was expecting a match for the presentation type: ${printPresentationSchema(keyword.acceptor)} but got ${TextPresentationRenderer.render(nextItem)}.`,

--- a/src/Command/PresentationTypeTranslator.ts
+++ b/src/Command/PresentationTypeTranslator.ts
@@ -1,0 +1,28 @@
+// Copyright 2024 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileAttributionText: <text>
+// This modified file incorporates work from @the-draupnir-project/interface-manager
+// https://github.com/the-draupnir-project/interface-manager
+// </text>
+
+import { Presentation, PresentationTypeWithoutWrap } from "./Presentation";
+
+export type PresentationTypeTranslator<From = unknown, To = unknown> = {
+  fromType: PresentationTypeWithoutWrap<From>;
+  toType: PresentationTypeWithoutWrap<To>;
+  translate(from: Presentation<From>): Presentation<To>;
+};
+
+export function describeTranslator<From, To>(
+  to: PresentationTypeWithoutWrap<To>,
+  from: PresentationTypeWithoutWrap<From>,
+  translate: (from: Presentation<From>) => Presentation<To>
+): PresentationTypeTranslator<From, To> {
+  return {
+    fromType: from,
+    toType: to,
+    translate,
+  };
+}

--- a/src/Command/RestParameterDescription.ts
+++ b/src/Command/RestParameterDescription.ts
@@ -22,7 +22,7 @@ import { PartialCommand } from "./Command";
 import {
   PresentationSchema,
   PresentationSchemaType,
-  checkPresentationSchema,
+  acceptPresentation,
   printPresentationSchema,
 } from "./PresentationSchema";
 
@@ -104,11 +104,12 @@ export class StandardRestDescription<ObjectType = unknown>
       }
       const nextItem = stream.peekItem(undefined);
       if (nextItem !== undefined) {
-        const validationResult = checkPresentationSchema(
+        const acceptedPresentation = acceptPresentation(
           this.acceptor,
+          partialCommand.commandTable,
           nextItem
         );
-        if (!validationResult) {
+        if (acceptedPresentation === undefined) {
           return ArgumentParseError.Result(
             `Was expecting a match for the presentation type: ${printPresentationSchema(this.acceptor)} but got ${TextPresentationRenderer.render(nextItem)}.`,
             {
@@ -117,7 +118,7 @@ export class StandardRestDescription<ObjectType = unknown>
             }
           );
         }
-        items.push(nextItem as Presentation<ObjectType>);
+        items.push(acceptedPresentation);
         stream.readItem(); // dispose of keyword's associated value from the stream.
       }
     }

--- a/src/Command/describeCommand.test.ts
+++ b/src/Command/describeCommand.test.ts
@@ -136,6 +136,7 @@ it("Can define keyword arguments.", async function () {
         readCommand(`--dry-run --room !foo:example.com`)
       ),
       KeywordsCommandTest,
+      new StandardCommandTable(Symbol("KeywordsCommandTest")),
       []
     )
   );

--- a/src/Command/index.ts
+++ b/src/Command/index.ts
@@ -17,5 +17,6 @@ export * from "./ParseErrors";
 export * from "./Presentation";
 export * from "./PresentationSchema";
 export * from "./PresentationStream";
+export * from "./PresentationTypeTranslator";
 export * from "./PromptForAccept";
 export * from "./RestParameterDescription";

--- a/src/TextReader/StandardCommandDispatcher.ts
+++ b/src/TextReader/StandardCommandDispatcher.ts
@@ -98,6 +98,7 @@ export class StandardCommandDispatcher<BasicInvocationInformation>
     const partialCommand = makePartialCommand(
       stream,
       commandToUse,
+      this.commandTable,
       normalisedDesignator
     );
     return Ok(partialCommand);

--- a/src/TextReader/TextCommandReader.test.ts
+++ b/src/TextReader/TextCommandReader.test.ts
@@ -83,3 +83,9 @@ it("Can parse userID's", function () {
   const user = readItems.at(0)?.object as MatrixUserID;
   expect(user.localpart).toBe("spam");
 });
+
+it("It can read numbers", function () {
+  const command = "123";
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.object).toBe(123);
+});

--- a/src/TextReader/TextCommandReader.ts
+++ b/src/TextReader/TextCommandReader.ts
@@ -28,6 +28,7 @@ import {
   MatrixRoomAliasPresentationType,
   MatrixRoomIDPresentationType,
   MatrixUserIDPresentationType,
+  NumberPresentationType,
   StringPresentationType,
 } from "./TextPresentationTypes";
 
@@ -279,4 +280,8 @@ definePostReadReplace(/^https:\/\/matrix\.to/, (input) => {
       }
     }
   }
+});
+
+definePostReadReplace(/^[0-9]+$/, (input) => {
+  return NumberPresentationType.wrap(Number.parseInt(input));
 });

--- a/src/TextReader/TextPresentationTypes.ts
+++ b/src/TextReader/TextPresentationTypes.ts
@@ -49,6 +49,26 @@ TextPresentationRenderer.registerPresentationRenderer<string>(
   }
 );
 
+export const NumberPresentationType = definePresentationType({
+  name: "number",
+  validator: function (value): value is number {
+    return typeof value === "number";
+  },
+  wrap(number: number): Presentation<number> {
+    return Object.freeze({
+      object: number,
+      presentationType: NumberPresentationType,
+    });
+  },
+});
+
+TextPresentationRenderer.registerPresentationRenderer<number>(
+  NumberPresentationType,
+  function (presentation) {
+    return presentation.object.toString();
+  }
+);
+
 export const KeywordPresentationType = definePresentationType({
   name: "Keyword",
   validator: function (value): value is Keyword {

--- a/src/TextReader/TextTranslators.test.ts
+++ b/src/TextReader/TextTranslators.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileAttributionText: <text>
+// This modified file incorporates work from @the-draupnir-project/interface-manager
+// https://github.com/the-draupnir-project/interface-manager
+// </text>
+
+import { Ok } from "@gnuxie/typescript-result";
+import { describeCommand } from "../Command/describeCommand";
+import { StandardCommandTable } from "../Command/CommandTable";
+import { StringPresentationType } from "./TextPresentationTypes";
+import { CommandDescription } from "../Command";
+import {
+  StringFromMatrixRoomAliasTranslator,
+  StringFromMatrixUserIDTranslator,
+  StringFromNumberTranslator,
+} from "./TextTranslators";
+import { StandardJSInterfaceCommandDispatcher } from "./JSInterfaceCommandDispatcher";
+import { StandardAdaptorContextToCommandContextTranslator } from "../Adaptor";
+import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
+
+const ReasonAcceptingCommand = describeCommand({
+  summary: "accepts a reason as a string",
+  parameters: [],
+  rest: {
+    name: "command arguments",
+    acceptor: StringPresentationType,
+  },
+  async executor(_context, _info, _keywords, rest) {
+    expect(rest.join(" ")).toBe(
+      "hello 1234 @foo:localhost:9999 https://matrix.to/#/%23bar%3Alocalhost%3A9999"
+    );
+    return Ok("Accepts a reason for a ban or something.");
+  },
+});
+
+const testTable = new StandardCommandTable(Symbol("TestTable"));
+
+const JSDispatcher = new StandardJSInterfaceCommandDispatcher(
+  testTable,
+  ReasonAcceptingCommand as CommandDescription,
+  undefined,
+  {},
+  new StandardAdaptorContextToCommandContextTranslator()
+);
+
+it("Can parse a partial command", async function () {
+  testTable.internCommand(ReasonAcceptingCommand as CommandDescription, [
+    "testbot",
+    "reason",
+  ]);
+  testTable
+    .internPresentationTypeTranslator(StringFromNumberTranslator)
+    .internPresentationTypeTranslator(StringFromMatrixUserIDTranslator)
+    .internPresentationTypeTranslator(StringFromMatrixRoomAliasTranslator);
+  const commandBody =
+    "testbot reason hello 1234 @foo:localhost:9999 https://matrix.to/#/#bar:localhost:9999";
+  const result = await JSDispatcher.invokeCommandFromBody(
+    { commandSender: "@foo:localhost:9999" as StringUserID },
+    commandBody
+  );
+  result.expect("Command should have worked");
+});

--- a/src/TextReader/TextTranslators.ts
+++ b/src/TextReader/TextTranslators.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describeTranslator } from "../Command/PresentationTypeTranslator";
+import {
+  MatrixEventReferencePresentationType,
+  MatrixRoomAliasPresentationType,
+  MatrixRoomIDPresentationType,
+  MatrixUserIDPresentationType,
+  NumberPresentationType,
+  StringPresentationType,
+} from "./TextPresentationTypes";
+
+export const StringFromNumberTranslator = describeTranslator(
+  StringPresentationType,
+  NumberPresentationType,
+  function (from) {
+    return StringPresentationType.wrap(from.object.toString());
+  }
+);
+
+export const StringFromMatrixRoomIDTranslator = describeTranslator(
+  StringPresentationType,
+  MatrixRoomIDPresentationType,
+  function (from) {
+    return StringPresentationType.wrap(from.object.toString());
+  }
+);
+
+export const StringFromMatrixRoomAliasTranslator = describeTranslator(
+  StringPresentationType,
+  MatrixRoomAliasPresentationType,
+  function (from) {
+    return StringPresentationType.wrap(from.object.toString());
+  }
+);
+
+export const StringFromMatrixUserIDTranslator = describeTranslator(
+  StringPresentationType,
+  MatrixUserIDPresentationType,
+  function (from) {
+    return StringPresentationType.wrap(from.object.toString());
+  }
+);
+
+export const StringFromMatrixEventReferenceTranslator = describeTranslator(
+  StringPresentationType,
+  MatrixEventReferencePresentationType,
+  function (from) {
+    return StringPresentationType.wrap(
+      `${from.object.reference.toPermalink()}/${from.object.eventID}`
+    );
+  }
+);

--- a/src/TextReader/index.ts
+++ b/src/TextReader/index.ts
@@ -7,3 +7,4 @@ export * from "./StandardCommandDispatcher";
 export * from "./TextCommandReader";
 export * from "./TextPresentationRenderer";
 export * from "./TextPresentationTypes";
+export * from "./TextTranslators";


### PR DESCRIPTION
These allow converting from one presentation type to another by adding translators to command tables.

Basically, if a command asks for a given type like a string, but instead the command parser has read something as a number or a `MatrixRoomID`, then we can provide a way to translate it to a string so that it can be accepted by the command. 