### PR TITLE
Improve the text command reader

### DIFF
--- a/src/TextReader/TextCommandReader.test.ts
+++ b/src/TextReader/TextCommandReader.test.ts
@@ -100,3 +100,9 @@ it("It can read booleans", function () {
   expect(readItems.at(0)?.object).toBe(true);
   expect(readItems.at(1)?.object).toBe(false);
 });
+
+it("It can read negative integers", function () {
+  const command = "-123";
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.object).toBe(-123);
+});

--- a/src/TextReader/TextCommandReader.test.ts
+++ b/src/TextReader/TextCommandReader.test.ts
@@ -106,3 +106,16 @@ it("It can read negative integers", function () {
   const readItems = readCommand(command);
   expect(readItems.at(0)?.object).toBe(-123);
 });
+
+it("It can read quoted strings", function () {
+  const command = '"hello world"';
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.object).toBe("hello world");
+});
+
+it("It can read unbalanced quoteds strings", function () {
+  const command = '"unbalanced vronut';
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.object).toBe('"unbalanced');
+  expect(readItems.at(1)?.object).toBe("vronut");
+});

--- a/src/TextReader/TextCommandReader.test.ts
+++ b/src/TextReader/TextCommandReader.test.ts
@@ -13,7 +13,10 @@ import {
   MatrixUserID,
 } from "@the-draupnir-project/matrix-basic-types";
 import { readCommand } from "./TextCommandReader";
-import { StringPresentationType } from "./TextPresentationTypes";
+import {
+  BooleanPresentationType,
+  StringPresentationType,
+} from "./TextPresentationTypes";
 import { Keyword } from "../Command/Keyword";
 
 test("CommandReader can read strings", function () {
@@ -88,4 +91,12 @@ it("It can read numbers", function () {
   const command = "123";
   const readItems = readCommand(command);
   expect(readItems.at(0)?.object).toBe(123);
+});
+
+it("It can read booleans", function () {
+  const command = "true false";
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.presentationType).toBe(BooleanPresentationType);
+  expect(readItems.at(0)?.object).toBe(true);
+  expect(readItems.at(1)?.object).toBe(false);
 });

--- a/src/TextReader/TextCommandReader.test.ts
+++ b/src/TextReader/TextCommandReader.test.ts
@@ -119,3 +119,16 @@ it("It can read unbalanced quoteds strings", function () {
   expect(readItems.at(0)?.object).toBe('"unbalanced');
   expect(readItems.at(1)?.object).toBe("vronut");
 });
+
+it("It can read escaped quotes meow", function () {
+  const commoand = '"\\"hello \\"';
+  const readItems = readCommand(commoand);
+  expect(readItems.at(0)?.object).toBe('"hello "');
+});
+
+it("It can stop quoted stuff from hitting the post read transforms", function () {
+  const command = '"true"';
+  const readItems = readCommand(command);
+  expect(readItems.at(0)?.object).toBe("true");
+  expect(readItems.at(0)?.presentationType).toBe(StringPresentationType);
+});

--- a/src/TextReader/TextCommandReader.ts
+++ b/src/TextReader/TextCommandReader.ts
@@ -23,6 +23,7 @@ import {
 import { Presentation } from "../Command/Presentation";
 import { Keyword } from "../Command/Keyword";
 import {
+  BooleanPresentationType,
   KeywordPresentationType,
   MatrixEventReferencePresentationType,
   MatrixRoomAliasPresentationType,
@@ -284,4 +285,8 @@ definePostReadReplace(/^https:\/\/matrix\.to/, (input) => {
 
 definePostReadReplace(/^[0-9]+$/, (input) => {
   return NumberPresentationType.wrap(Number.parseInt(input));
+});
+
+definePostReadReplace(/^true|false$/, (input) => {
+  return BooleanPresentationType.wrap(input === "true");
 });

--- a/src/TextReader/TextPresentationTypes.ts
+++ b/src/TextReader/TextPresentationTypes.ts
@@ -69,6 +69,26 @@ TextPresentationRenderer.registerPresentationRenderer<number>(
   }
 );
 
+export const BooleanPresentationType = definePresentationType({
+  name: "boolean",
+  validator: function (value): value is boolean {
+    return typeof value === "boolean";
+  },
+  wrap(boolean: boolean): Presentation<boolean> {
+    return Object.freeze({
+      object: boolean,
+      presentationType: BooleanPresentationType,
+    });
+  },
+});
+
+TextPresentationRenderer.registerPresentationRenderer<boolean>(
+  BooleanPresentationType,
+  function (presentation) {
+    return presentation.object ? "true" : "false";
+  }
+);
+
 export const KeywordPresentationType = definePresentationType({
   name: "Keyword",
   validator: function (value): value is Keyword {

--- a/src/TextReader/TextTranslators.test.ts
+++ b/src/TextReader/TextTranslators.test.ts
@@ -13,6 +13,7 @@ import { StandardCommandTable } from "../Command/CommandTable";
 import { StringPresentationType } from "./TextPresentationTypes";
 import { CommandDescription } from "../Command";
 import {
+  StringfromBooleanTranslator,
   StringFromMatrixRoomAliasTranslator,
   StringFromMatrixUserIDTranslator,
   StringFromNumberTranslator,
@@ -30,7 +31,7 @@ const ReasonAcceptingCommand = describeCommand({
   },
   async executor(_context, _info, _keywords, rest) {
     expect(rest.join(" ")).toBe(
-      "hello 1234 @foo:localhost:9999 https://matrix.to/#/%23bar%3Alocalhost%3A9999"
+      "hello 1234 @foo:localhost:9999 https://matrix.to/#/%23bar%3Alocalhost%3A9999 false"
     );
     return Ok("Accepts a reason for a ban or something.");
   },
@@ -54,9 +55,10 @@ it("Can parse a partial command", async function () {
   testTable
     .internPresentationTypeTranslator(StringFromNumberTranslator)
     .internPresentationTypeTranslator(StringFromMatrixUserIDTranslator)
-    .internPresentationTypeTranslator(StringFromMatrixRoomAliasTranslator);
+    .internPresentationTypeTranslator(StringFromMatrixRoomAliasTranslator)
+    .internPresentationTypeTranslator(StringfromBooleanTranslator);
   const commandBody =
-    "testbot reason hello 1234 @foo:localhost:9999 https://matrix.to/#/#bar:localhost:9999";
+    "testbot reason hello 1234 @foo:localhost:9999 https://matrix.to/#/#bar:localhost:9999 false";
   const result = await JSDispatcher.invokeCommandFromBody(
     { commandSender: "@foo:localhost:9999" as StringUserID },
     commandBody

--- a/src/TextReader/TextTranslators.ts
+++ b/src/TextReader/TextTranslators.ts
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describeTranslator } from "../Command/PresentationTypeTranslator";
+import { TextPresentationRenderer } from "./TextPresentationRenderer";
 import {
+  BooleanPresentationType,
   MatrixEventReferencePresentationType,
   MatrixRoomAliasPresentationType,
   MatrixRoomIDPresentationType,
@@ -17,6 +19,14 @@ export const StringFromNumberTranslator = describeTranslator(
   NumberPresentationType,
   function (from) {
     return StringPresentationType.wrap(from.object.toString());
+  }
+);
+
+export const StringfromBooleanTranslator = describeTranslator(
+  StringPresentationType,
+  BooleanPresentationType,
+  function (from) {
+    return StringPresentationType.wrap(TextPresentationRenderer.render(from));
   }
 );
 


### PR DESCRIPTION
1. Add a boolean presentation type and translator
2. Allow the text command reader to read negative integers
3. Add simple quoted strings which are unbalanced quote resistant.

- [ ] Remember to add the BooleanPresnetationTypeTranslator to draupnir. 